### PR TITLE
Change com and iframe to use hashData for encoding/decoding of the hash

### DIFF
--- a/src/lib/com.js
+++ b/src/lib/com.js
@@ -93,18 +93,4 @@ com.createManagerConnection = function(origin, prefix) {
     return com.createOutgoing(origin, global.parent || global.top, prefix);
 };
 
-var RE_SPLIT = /&/gm;
-com.getHash = function(hash) {
-    var args = (hash||global.location.hash).split('_|_');
-    if (args[0] !== '#' + com.PREFIX) {
-        throw new Error('Missing #'+com.PREFIX);
-    }
-
-    return {
-        name: args[1],
-        internal: paramUtil.deparam(args[2], RE_SPLIT),
-        params: paramUtil.deparam(args[3], RE_SPLIT)
-    };
-};
-
 module.exports = com;

--- a/src/lib/hashData.js
+++ b/src/lib/hashData.js
@@ -1,0 +1,29 @@
+var paramUtil = require('./paramUtil.js');
+var RE_SPLIT = /&/gm;
+
+module.exports = {
+	PREFIX : 'PASTIES',
+	SEPARATOR : '_|_',
+	HASH_CHAR : '#',
+
+	encode: function (name, internalParams, params) {
+		return [
+			this.HASH_CHAR + this.PREFIX,
+			name,
+			paramUtil.param(internalParams),
+			paramUtil.param(params)
+		].join(this.SEPARATOR);
+	},
+
+	decode: function (hash) {
+		var parts = hash.split(this.SEPARATOR);
+		if (parts[0] !== this.HASH_CHAR + this.PREFIX) {
+			throw new Error('Missing url-fragment prefix ' + this.HASH_CHAR + this.PREFIX);
+		}
+		return {
+			name: parts[1],
+			internals: paramUtil.deparam(parts[2], RE_SPLIT),
+			params: paramUtil.deparam(parts[3], RE_SPLIT)
+		};
+	}
+};

--- a/src/lib/hashData.js
+++ b/src/lib/hashData.js
@@ -22,7 +22,7 @@ module.exports = {
 		}
 		return {
 			name: parts[1],
-			internals: paramUtil.deparam(parts[2], RE_SPLIT),
+			internal: paramUtil.deparam(parts[2], RE_SPLIT),
 			params: paramUtil.deparam(parts[3], RE_SPLIT)
 		};
 	}

--- a/src/lib/iframe.js
+++ b/src/lib/iframe.js
@@ -1,5 +1,5 @@
 var com = require('./com.js');
-var paramUtil = require('./paramUtil.js');
+var hashData = require('./hashData.js');
 
 var VER = 1;
 var TYPE = 'pasties';
@@ -73,13 +73,7 @@ Iframe.prototype._getUrl = function(src) {
         '&',
         refresh,
         // Wrapped args in predefined order
-        '#',
-        com.PREFIX,
-        SEPARATOR,
-        this.name,
-        SEPARATOR, ['level=' + 1, 'key=' + this.key, 'origin=' + getOrigin(document.location)].join('&'),
-        SEPARATOR,
-        paramUtil.param(this.data)
+        hashData.encode(this.name, {key: this.key, origin: getOrigin(document.location)}, this.data)
     ].join('');
 };
 

--- a/src/lib/iframe.js
+++ b/src/lib/iframe.js
@@ -7,7 +7,7 @@ var REFRESH_KEY = 'refresh-' + TYPE;
 var FAILED_CLASS = TYPE + '-failed';
 var SEPARATOR = '_|_';
 
-function validWidth(v) {
+function validSize(v) {
     if (typeof v === 'string' && v.indexOf('px') !== -1) { return v; }
     if ( (typeof v === 'string' && v.indexOf('%') === -1) || typeof v === 'number') {
         return v + 'px';
@@ -25,7 +25,7 @@ function Iframe(name, options) {
         throw new Error('Iframe missing options and iframeUrl');
     }
     this.id = options.id || name + (+new Date());
-    this.iframe = null;
+    this.element = null;
     this.iframeUrl = options.iframeUrl;
     this.width = options.width || '100%';
     this.height = options.height || '100px';
@@ -39,15 +39,15 @@ Iframe.prototype.SEPARATOR = SEPARATOR;
 Iframe.prototype.remove = function() {
     this.wrapper.parentNode.removeChild(this.wrapper);
     this.wrapper = null;
-    this.iframe = null;
+    this.element = null;
     return this;
 };
 
 Iframe.prototype.resize = function(w, h) {
     if (w) { this.width = w; }
     if (h) { this.height = h; }
-    this.iframe.style.width = validWidth(this.width);
-    this.iframe.style.height = this.height + 'px';
+    this.element.style.width = validSize(this.width);
+    this.element.style.height = validSize(this.height);
     return this;
 };
 
@@ -84,13 +84,12 @@ Iframe.prototype._getUrl = function(src) {
 };
 
 Iframe.prototype.refresh = function () {
-    this.iframe.src = this._getUrl(this.iframe.src);
+    this.element.src = this._getUrl(this.element.src);
 };
 
-Iframe.prototype.makeIframe = function(data) {
-    this.dataStr = paramUtil.param(data);
+Iframe.prototype.makeIframe = function() {
     var wrapper = this.wrapper = document.createElement('div');
-    var i = this.iframe = document.createElement('iframe');
+    var i = this.element = document.createElement('iframe');
     var inner = document.createElement('div');
     var classes = [TYPE, TYPE + '-' + this.name];
 
@@ -114,10 +113,10 @@ Iframe.prototype.makeIframe = function(data) {
     i.frameBorder = '0';
     i.allowTransparency = 'true';
     // Safari will will not show iframe until scroll with width/height == 0px
-    i.width = validWidth(this.width);
-    i.height = this.height;
-    i.style.width = validWidth(this.width);
-    i.style.height = this.height + 'px';
+    //i.width = validSize(this.width);
+    //i.height = this.height;
+    i.style.width = validSize(this.width);
+    i.style.height = validSize(this.height);
     i.style.border = '0';
     i.style.display = 'block';
     // stop scroll

--- a/src/lib/paramUtil.js
+++ b/src/lib/paramUtil.js
@@ -1,8 +1,5 @@
-var util = require('./utility.js');
-
 var paramUtils = {};
 
-/* using escape and unescape for utf8/iso-issues? */
 var REXP_SPLIT = /&amp;|&|;/gmi;
 paramUtils.deparam = function(str, sep) {
     sep = sep||REXP_SPLIT;
@@ -24,7 +21,8 @@ paramUtils.param = function(o, sep) {
     var list = [];
     var key;
     for (key in o) {
-        if (typeof o[key] !== 'undefined' && typeof o[key] !== 'object' && !util.isFunction(o[key])) {
+        if (o[key] != null && typeof o[key] != 'object' &&
+                typeof o[key] != 'function') {
             list.push(encodeURIComponent(key) + '=' + encodeURIComponent(o[key]));
         }
     }

--- a/src/mobile-inframe.js
+++ b/src/mobile-inframe.js
@@ -9,12 +9,14 @@ var support     = require('./lib/support.js');
 var plugin      = require('./lib/plugins/contextData.js');
 var rAFPatch    = require('./lib/raf.js');
 var feed        = require('./lib/feed.js');
+//var hashData    = require('./lib/hashData');
 
 /*
     Mobile inframe.
     * fetch setupdata (parentUrl, level) from query/hash
 */
 var input = com.getHash();
+//var input = hashData.decode(global.location.hash);
 
 if (input.params.cdfs === 'true'){
     global[support.cdfsKey] = true;

--- a/src/mobile-inframe.js
+++ b/src/mobile-inframe.js
@@ -9,14 +9,13 @@ var support     = require('./lib/support.js');
 var plugin      = require('./lib/plugins/contextData.js');
 var rAFPatch    = require('./lib/raf.js');
 var feed        = require('./lib/feed.js');
-//var hashData    = require('./lib/hashData');
+var hashData    = require('./lib/hashData.js');
 
 /*
     Mobile inframe.
     * fetch setupdata (parentUrl, level) from query/hash
 */
-var input = com.getHash();
-//var input = hashData.decode(global.location.hash);
+var input = hashData.decode(window.location.hash);
 
 if (input.params.cdfs === 'true'){
     global[support.cdfsKey] = true;

--- a/test/ig/crossdomain.test.js
+++ b/test/ig/crossdomain.test.js
@@ -51,7 +51,7 @@ describe('Cross domain iframe test', function () {
                     done = true;
                 }
 
-                var src = item.iframe.iframe.getAttribute('src');
+                var src = item.iframe.element.getAttribute('src');
 
                 // as this will test in not usable browsers, we need to asure result
 
@@ -104,7 +104,7 @@ describe('Cross domain iframe test', function () {
             expect(item.input.height).toEqual(300);
             // cdfs_fallback sets a global from iframe. This wont work deactivateCDFS failed
             expect(window[name]).toEqual(name);
-            var src = item.iframe.iframe.getAttribute('src');
+            var src = item.iframe.element.getAttribute('src');
             expect(src.indexOf(base) === -1).toBe(true);
             done = true;
         });

--- a/test/unit/com.test.js
+++ b/test/unit/com.test.js
@@ -8,30 +8,6 @@ describe('Communcation / Messaging', function () {
         expect(com).toEqual(jasmine.any(Object));
     });
 
-    describe('getHash', function(){
-        //firefox returns addyn?
-
-        //http://helios.finn.no/addyn|3.0|72.23|4489198|0|16|ADTECH;cookie=info;loc=100;target=_blank;alias=realestate%2Fnewbuildings%2Fsearch%2Flist_mm;grp=196228776;kvuserid=1754579083;misc=527682197289185
-
-        var result = com.getHash(
-            '#'+com.PREFIX+'_|_1_|_a=a_|_a=a&url=http%3A//helios.finn.no/addyn%7C3.0%7C72.23%7C4489198%7C0%7C16%7CADTECH%3Bcookie%3Dinfo%3Bloc%3D100%3Btarget%3D_blank%3Balias%3Drealestate%252Fnewbuildings%252Fsearch%252Flist_mm%3Bgrp%3D196228776%3Bkvuserid%3D1754579083%3Bmisc%3D527682197289185&b=b&c=c&d=d'
-        );
-
-        it('should deparam internal and params', function(){
-            expect(result.name).toEqual('1');
-            expect(result.internal.a).toEqual('a');
-            expect(result.params.a).toEqual('a');
-            expect(result.params.b).toEqual('b');
-
-            expect(result.params.url)
-                .toEqual('http://helios.finn.no/addyn|3.0|72.23|4489198|0|16|ADTECH;cookie=info;loc=100;target=_blank;alias=realestate%2Fnewbuildings%2Fsearch%2Flist_mm;grp=196228776;kvuserid=1754579083;misc=527682197289185');
-
-        });
-
-
-
-    });
-
     function getOrigin(loc) {
         return loc.origin || (loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port : ''));
     }

--- a/test/unit/hashData.test.js
+++ b/test/unit/hashData.test.js
@@ -6,7 +6,7 @@ var S = hashData.SEPARATOR;
 
 describe('Hash data', function () {
     var TESTNAME = 'testName';
-    var INTERNALS = {key: 'testKey', origin: 'testLoc'};
+    var INTERNAL = {key: 'testKey', origin: 'testLoc'};
     var PARAMS = {
         url:    'http://some.url/?with=query&string=true&andChars=æøå',
         width:  '100%',
@@ -26,11 +26,11 @@ describe('Hash data', function () {
         });
 
         it('should encode with only name and internals', function () {
-            expect(hashData.encode(TESTNAME, INTERNALS)).toEqual( ENCODED_NAME_INT );
+            expect(hashData.encode(TESTNAME, INTERNAL)).toEqual( ENCODED_NAME_INT );
         });
 
         it('should encode with name, internals and params', function () {
-            expect(hashData.encode(TESTNAME, INTERNALS, PARAMS)).toEqual( ENCODED_NAME_INT_PAR );
+            expect(hashData.encode(TESTNAME, INTERNAL, PARAMS)).toEqual( ENCODED_NAME_INT_PAR );
         });
     });
 
@@ -38,21 +38,21 @@ describe('Hash data', function () {
         it('should decode with only name', function () {
             var res = hashData.decode(ENCODED_NAME);
             expect(res.name).toEqual(TESTNAME);
-            expect(res.internals).toEqual({});
+            expect(res.internal).toEqual({});
             expect(res.params).toEqual({});
         });
 
         it('should decode with name and internals', function () {
             var res = hashData.decode(ENCODED_NAME_INT);
             expect(res.name).toEqual(TESTNAME);
-            expect(res.internals).toEqual( INTERNALS );
+            expect(res.internal).toEqual( INTERNAL );
             expect(res.params).toEqual({});
         });
 
         it('should decode with name, internals and params', function () {
             var res = hashData.decode(ENCODED_NAME_INT_PAR);
             expect(res.name).toEqual(TESTNAME);
-            expect(res.internals).toEqual( INTERNALS );
+            expect(res.internal).toEqual( INTERNAL );
             for(var key in PARAMS) {
                 expect(res.params[key]).toEqual(PARAMS[key].toString());
             }

--- a/test/unit/hashData.test.js
+++ b/test/unit/hashData.test.js
@@ -1,0 +1,69 @@
+var hashData = require('../../src/lib/hashData.js');
+
+var H = hashData.HASH_CHAR;
+var P = hashData.PREFIX;
+var S = hashData.SEPARATOR;
+
+describe('Hash data', function () {
+    var TESTNAME = 'testName';
+    var INTERNALS = {key: 'testKey', origin: 'testLoc'};
+    var PARAMS = {
+        url:    'http://some.url/?with=query&string=true&andChars=æøå',
+        width:  '100%',
+        height: 100
+    };
+
+    var ENCODED_NAME = H + P + S + TESTNAME + S + S;
+    var ENCODED_NAME_INT = H + P + S + TESTNAME + S +
+            'key=testKey&origin=testLoc' + S;
+    var ENCODED_NAME_INT_PAR = ENCODED_NAME_INT +
+            'url=http%3A%2F%2Fsome.url%2F%3Fwith%3Dquery%26string%3Dtrue%26a' +
+            'ndChars%3D%C3%A6%C3%B8%C3%A5&width=100%25&height=100';
+
+    describe('encode', function () {
+        it('should encode with only name', function () {
+            expect(hashData.encode(TESTNAME)).toEqual( ENCODED_NAME );
+        });
+
+        it('should encode with only name and internals', function () {
+            expect(hashData.encode(TESTNAME, INTERNALS)).toEqual( ENCODED_NAME_INT );
+        });
+
+        it('should encode with name, internals and params', function () {
+            expect(hashData.encode(TESTNAME, INTERNALS, PARAMS)).toEqual( ENCODED_NAME_INT_PAR );
+        });
+    });
+
+    describe('decode', function () {
+        it('should decode with only name', function () {
+            var res = hashData.decode(ENCODED_NAME);
+            expect(res.name).toEqual(TESTNAME);
+            expect(res.internals).toEqual({});
+            expect(res.params).toEqual({});
+        });
+
+        it('should decode with name and internals', function () {
+            var res = hashData.decode(ENCODED_NAME_INT);
+            expect(res.name).toEqual(TESTNAME);
+            expect(res.internals).toEqual( INTERNALS );
+            expect(res.params).toEqual({});
+        });
+
+        it('should decode with name, internals and params', function () {
+            var res = hashData.decode(ENCODED_NAME_INT_PAR);
+            expect(res.name).toEqual(TESTNAME);
+            expect(res.internals).toEqual( INTERNALS );
+            for(var key in PARAMS) {
+                expect(res.params[key]).toEqual(PARAMS[key].toString());
+            }
+        });
+
+        it('should throw an error if the prefix is not included in hash', function(){
+            var prefixLen = H.length + P.length;
+            var urlStr = ENCODED_NAME.substring(prefixLen);
+            expect(function(){
+                hashData.decode(urlStr);
+            }).toThrow();
+        });
+    });
+});

--- a/test/unit/iframe.test.js
+++ b/test/unit/iframe.test.js
@@ -25,29 +25,37 @@ describe('iframe', function () {
 
         frame.makeIframe('some=parameters&and=another');
 
-        expect(frame.iframe.src.indexOf(iframeUrl) === 0).toBe(true);
+        expect(frame.element.src.indexOf(iframeUrl) === 0).toBe(true);
 
 
         //....
     });
 
+    it('should have width and height from constructor options', function(){
+        var iframe = new Iframe('resize-test', {width:100, height:200, iframeUrl:'about:blank'});
+        iframe.makeIframe();
+        //expect(iframe.element.width).toEqual('100px');
+        expect(iframe.element.style.width).toEqual('100px');
+        expect(iframe.element.style.height).toEqual('200px');
+    });
+
     it('should encode data object to query string', function () {
         var iframe = new Iframe('data-test', {iframeUrl: 'about:blank'});
         iframe.setData({
-            width: 100,
+            aNumber: 100,
             encodeUrl: 'http://test.com/path?a=b&c=æøå'
         });
         iframe.makeIframe();
-        var lastSepIndex = iframe.iframe.src.lastIndexOf(Iframe.prototype.SEPARATOR);
-        var dataStr = iframe.iframe.src.substring(lastSepIndex + Iframe.prototype.SEPARATOR.length);
-        expect(dataStr).toEqual('width=100&encodeUrl=http%3A%2F%2Ftest.com%2Fpath%3Fa%3Db%26c%3D%C3%A6%C3%B8%C3%A5');
+        var lastSepIndex = iframe.element.src.lastIndexOf(Iframe.prototype.SEPARATOR);
+        var dataStr = iframe.element.src.substring(lastSepIndex + Iframe.prototype.SEPARATOR.length);
+        expect(dataStr).toEqual('aNumber=100&encodeUrl=http%3A%2F%2Ftest.com%2Fpath%3Fa%3Db%26c%3D%C3%A6%C3%B8%C3%A5');
     });
 
     it('should resize', function(){
         var iframe = new Iframe('resize-test', {width:100, height:100, iframeUrl:'about:blank'});
         iframe.makeIframe();
         iframe.resize(250, 200);
-        expect(iframe.iframe.style.width).toEqual('250px');
-        expect(iframe.iframe.style.height).toEqual('200px');
+        expect(iframe.element.style.width).toEqual('250px');
+        expect(iframe.element.style.height).toEqual('200px');
     });
 });

--- a/test/unit/manager.test.js
+++ b/test/unit/manager.test.js
@@ -216,35 +216,48 @@ describe('Manager', function () {
             expect(manager.callbacks[name]).toEqual(jasmine.any(Array));
         });
 
-        it('should create a iframe and pass data', function () {
+        it('should create an iframe', function () {
             var name = helpers.getRandomName();
-            var done = false;
 
             manager.queue(name, {
                 container: document.createElement('div'),
-                url: scriptUrl,
-                width: 999,
-                height: 444
+                url: 'test'
             });
-
             expect(manager._get(name).iframe).toBeUndefined();
+            manager.render(name, function () {});
 
-            manager.render(name, function () {
-                expect(manager._get(name).state).toEqual(State.RESOLVED);
-                done = true;
+            expect(manager._get(name).iframe).toBeDefined();
+        });
+
+        it('should pass width and height to iframe', function () {
+            var name = helpers.getRandomName();
+            var width = 999;
+            var height = 444;
+
+            manager.queue(name, {
+                container: document.createElement('div'),
+                url: 'test',
+                width: width,
+                height: height
             });
+            manager.render(name, function () {});
 
-            var iframeElem = manager._get(name).iframe.iframe;
+            var iframe = manager._get(name).iframe;
+            expect(iframe.width).toEqual(width);
+            expect(iframe.height).toEqual(height);
 
-            expect(iframeElem).toBeDefined();
-            var style = iframeElem.getAttribute('style').toString();
-            expect(style.indexOf('999px') !== -1 && style.indexOf('444px') !== -1).toBe(true);
+        });
 
-            manager._resolve(name);
+        it('should set script url as data on iframe', function () {
+            var name = helpers.getRandomName();
 
-            waitsFor(function () {
-                return done;
+            manager.queue(name, {
+                container: document.createElement('div'),
+                url: scriptUrl
             });
+            
+            manager.render(name, function () {});
+            expect(manager._get(name).iframe.data.url).toEqual(scriptUrl);
 
         });
 
@@ -507,13 +520,13 @@ describe('Manager', function () {
                 expect(item.state).toEqual(State.RESOLVED);
 
                 expect(item.rendered).toEqual(1);
-                var beforeSrc = item.iframe.iframe.src;
+                var beforeSrc = item.iframe.element.src;
 
                 manager.refresh(name, function (err, item) {
 
                     expect(item.rendered).toEqual(2);
-                    expect(item.iframe.iframe.src).not.toBeUndefined();
-                    expect(item.iframe.iframe.src).not.toEqual(beforeSrc);
+                    expect(item.iframe.element.src).not.toBeUndefined();
+                    expect(item.iframe.element.src).not.toEqual(beforeSrc);
                     done = true;
                 });
 


### PR DESCRIPTION
The url-fragment appended to the iframe src was encoded in iframe.js and decoded in com. This moves the encoding and decoding to the same module, and adds test coverage.
