### PR TITLE
Deleted extend methods from utility and use util-extend instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "get-style-property": "~0.1.1",
     "cookies-js": "~0.3.1",
     "browserify": "~2.35.1",
-    "query-params": "~0.0.1"
+    "query-params": "~0.0.1",
+    "util-extend": "~1.0.1"
   },
   "engines": {
     "node": ">=0.10.15"

--- a/src/lib/feed.js
+++ b/src/lib/feed.js
@@ -1,4 +1,4 @@
-var util = require('./utility.js');
+var extend = require('util-extend');
 var queryParams = require('query-params');
 
 var ADTECH_SPLIT = '|ADTECH;';
@@ -23,7 +23,7 @@ function extractFeed(scriptUrl) {
 
     return {
         inject: function(inject) {
-            return _url[0] + ADTECH_SPLIT + queryParams.encode(util.extend({}, feed, inject), ';');
+            return _url[0] + ADTECH_SPLIT + queryParams.encode(extend(feed, inject), ';');
         },
         feedStr: _url[1],
         feed: feed

--- a/src/lib/log/logger.js
+++ b/src/lib/log/logger.js
@@ -1,5 +1,6 @@
 /* jshint noarg:false */
 var util = require('../utility.js');
+var extend = require('util-extend');
 var CALLSTACK_MAX_DEPTH = 10;
 var FN_NAME_REGEX = /function ([\w\d\-_]+)\s*\(/;
 
@@ -13,7 +14,7 @@ function makeLogFn (out, name) {
             if (typeof objOrMsg === 'string') {
                 objOrMsg = {msg: objOrMsg};
             }
-            out( util.extend({
+            out( extend({
                 level: level,
                 name: name,
                 time: new Date().getTime()

--- a/src/lib/manager.js
+++ b/src/lib/manager.js
@@ -2,6 +2,7 @@
 'use strict';
 var State = require('./state.js');
 var utility = require('./utility.js');
+var extend = require('util-extend');
 var Iframe = require('./iframe.js');
 var com = require('./com.js');
 var support = require('./support.js');
@@ -147,7 +148,7 @@ proto._delegate = function (msg, item) {
 
 proto.extendInframeData = function (o) {
     if (o) {
-        utility.extend(this.__inject, o);
+        extend(this.__inject, o);
     }
 };
 
@@ -183,7 +184,7 @@ proto.queue = function (name, obj) {
         input.container = document.body.appendChild( document.createElement('div') );
     }
     var item = State.create(name);
-    this.items.push( utility.extend(item, config, input) );
+    this.items.push( extend( extend(item, config), input) );
 };
 
 /* Insert iframe into page. */
@@ -251,7 +252,7 @@ proto.renderAll = function(prioritized, cb) {
 };
 
 proto._getItemData = function (item) {
-    return utility.extend(item.getData(), this.__inject);
+    return extend(item.getData(), this.__inject);
 };
 
 proto.createIframe = function (item) {
@@ -276,7 +277,7 @@ proto.createIframe = function (item) {
 
 proto._setCallback = function(name, cb) {
     var list = this.callbacks[name];
-    if (!utility.isArray(this.callbacks[name])) {
+    if (!this.callbacks[name]) {
         list = this.callbacks[name] = [];
     }
     if (utility.isFunction(cb)) {

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -1,3 +1,4 @@
+var extend = require('util-extend');
 var utility = require('./utility');
 /*
     Banner state
@@ -41,12 +42,12 @@ var UNIQUE_TOKEN_REGEX = /PASTIES_UNIQUE_ID/g;
 var uniqueCount = 0;
 
 function State(name, options) {
-    utility.extend(this, DEFAULTS, options);
+    extend( extend(this, DEFAULTS), options);
     this.name = name;
     this.id = name + (++uniqueCount);
 }
 
-utility.extend(State, STATES);
+extend(State, STATES);
 var proto = State.prototype;
 
 proto.isActive = function() {

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -4,31 +4,6 @@ var typeOf = function(a, b) {
     return typeof a === b;
 };
 
-function _extend(target, list, dontCopyKeyList) {
-    list.forEach(function(src) {
-        if (!src) {
-            return;
-        }
-        var key;
-        for (key in src) {
-            if (dontCopyKeyList.indexOf(key) === -1 && !typeOf(src[key], 'undefined') && src.hasOwnProperty(key)) {
-                target[key] = src[key];
-            }
-        }
-    });
-    return target;
-}
-
-utility.extendExcept = function(keys) {
-    return function(target) {
-        return _extend(target, Array.prototype.slice.call(arguments, 1), keys);
-    };
-};
-
-utility.extend = function(target) {
-    return _extend(target, Array.prototype.slice.call(arguments, 1), []);
-};
-
 utility.on = function(name, elem, func) {
     if (elem.addEventListener) {
         elem.addEventListener(name, func, false);

--- a/test/unit/utility.test.js
+++ b/test/unit/utility.test.js
@@ -7,33 +7,6 @@ describe('utility', function() {
         expect(utility).toEqual(jasmine.any(Object));
     });
 
-    describe('extend', function(){
-        var ext = utility.extend;
-
-        expect(ext).toBeDefined();
-        expect(ext({}));
-
-        var expected = {a: 'a', b: 'b'};
-
-        var input = ext({a: 'a'}, {b: 'b'});
-        expect(input).toEqual(expected);
-
-        input = ext({}, {a: '_'}, {b: '_'}, {a: 'a'}, {b: 'b'}, {});
-        expect(input).toEqual(expected);
-    });
-
-    it('extendExcept', function(){
-
-        var a = {'a':'a', 'not':'b'};
-        var result = utility.extendExcept(['not'])({}, a);
-
-        expect(result).toEqual(jasmine.any(Object));
-        expect(result.not).toBeUndefined();
-        expect(result.a).toEqual('a');
-
-
-    });
-
     it('isFunction', function(){
         expect(utility.isFunction(function(){})).toBe(true);
         expect(utility.isFunction(false)).toBe(false);


### PR DESCRIPTION
Use https://github.com/isaacs/util-extend from npm instead of defining our own. Deleted methods from utility and changed code that used them.
