### PR TITLE
Remove isType methods from utility and use typeof instead

### DIFF
--- a/src/desktop-inframe.js
+++ b/src/desktop-inframe.js
@@ -63,7 +63,7 @@ var internals = global.banner = api.init(input, comParent, getSizes, logAppender
 */
 com.incomming(function(msg) {
     //parent.console.log('incomming msg', internals.id, msg);
-    if (msg.cmd === 'callback' && utility.isNumber(msg.index)) {
+    if (msg.cmd === 'callback' && typeof msg.index == 'number') {
         internals.callback(msg);
     } else if (msg.cmd === 'getSizes') {
         internals.processSize();

--- a/src/lib/com.js
+++ b/src/lib/com.js
@@ -20,7 +20,7 @@ var getOriginFromUrl = function(url) {
 
 /*  */
 com._postMessage = function(targetOrigin, targetWindow, prefix) {
-    prefix = utility.isString(prefix) ? prefix : com.PREFIX;
+    prefix = (typeof prefix == 'string') ? prefix : com.PREFIX;
     // targetOrigin implementation deviates in IE8, "*" not supported
     if (!targetOrigin || targetOrigin === '*') {
         targetOrigin = getOriginFromUrl(window.location.toString());
@@ -58,7 +58,7 @@ com._postMessage = function(targetOrigin, targetWindow, prefix) {
 
 /* Handle incomming messages */
 com.incomming = function(cb, prefix, deactivateCDFS) {
-    if (!utility.isFunction(cb)) {
+    if (typeof cb != 'function') {
         throw new Error('Missing callback');
     }
     prefix = prefix || com.PREFIX;
@@ -68,7 +68,7 @@ com.incomming = function(cb, prefix, deactivateCDFS) {
         // todo... document not working o nchrome
         utility.on('message', global, function(e) {
             var res = e.data;
-            if (res && utility.isString(res) && res.indexOf(prefix) === 0) {
+            if (res && typeof res == 'string' && res.indexOf(prefix) === 0) {
                 try {
                     var input = res.substring(prefix.length);
                     res = JSON.parse(input);

--- a/src/lib/manager.js
+++ b/src/lib/manager.js
@@ -201,7 +201,7 @@ proto.render = function (name, cb) {
             return this._resolve(item.id, new Error(name + ' missing queued config'));
         }
 
-        if (utility.isString(item.container)) {
+        if (typeof item.container == 'string') {
             item.container = document.getElementById(item.container);
             if (!item.container) {
                 return this._resolve(item.id, new Error(name + ' missing container'));
@@ -224,14 +224,14 @@ proto.render = function (name, cb) {
 };
 
 function commaStringToArray(list) {
-    if (!utility.isString(list)) {
+    if (typeof list != 'string') {
         return [];
     }
     return list.split(',');
 }
 
 proto.renderAll = function(prioritized, cb) {
-    if (utility.isFunction(prioritized)) {
+    if (typeof prioritized == 'function') {
         cb = prioritized;
         prioritized = undefined;
     }
@@ -280,7 +280,7 @@ proto._setCallback = function(name, cb) {
     if (!this.callbacks[name]) {
         list = this.callbacks[name] = [];
     }
-    if (utility.isFunction(cb)) {
+    if (typeof cb == 'function') {
         list.push(cb);
     }
 };
@@ -314,7 +314,7 @@ proto._resolve = function(id, error, ignoreNewState) {
         item.rendered++;
         item.set(State.RESOLVED);
     }
-    if (item && utility.isFunction(item[type])){
+    if (item && typeof item[type] == 'function'){
         item[type](error, item);
     }
     if (item && item.isResolved()) {
@@ -383,7 +383,7 @@ proto.refresh = function(name, cb) {
 };
 
 proto.refreshAll = function(prioritized, cb) {
-    if (utility.isFunction(prioritized)) {
+    if (typeof prioritized == 'function') {
         cb = prioritized;
         prioritized = undefined;
     }

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -73,7 +73,7 @@ proto.hasFailed = function(){
 
 proto.set = function(input) {
     this.lastState = this.state;
-    this.state = utility.isNumber(input) ? input : State[input];
+    this.state = (typeof input == 'number') ? input : State[input];
 };
 
 proto.getData = function() {

--- a/src/lib/utility.js
+++ b/src/lib/utility.js
@@ -1,39 +1,11 @@
 var utility = {};
 
-var typeOf = function(a, b) {
-    return typeof a === b;
-};
-
 utility.on = function(name, elem, func) {
     if (elem.addEventListener) {
         elem.addEventListener(name, func, false);
     } else if (elem.attachEvent) {
         elem.attachEvent('on' + name, func);
     }
-};
-
-utility.isFunction = function(fn) {
-    return typeOf(fn, 'function');
-};
-
-utility.isArray = function (arg) {
-    return Object.prototype.toString.call(arg) === '[object Array]';
-};
-
-utility.isUndef = function(v) {
-    return typeOf(v, 'undefined');
-};
-
-utility.isString = function(v) {
-    return typeOf(v, 'string');
-};
-
-utility.isNumber = function(v) {
-    return typeOf(v, 'number');
-};
-
-utility.isBoolean = function(v) {
-    return typeOf(v, 'boolean');
 };
 
 module.exports = utility;

--- a/src/mobile-inframe.js
+++ b/src/mobile-inframe.js
@@ -63,7 +63,7 @@ var internals = global.banner = api.init(input, comParent, getSizes, logAppender
 */
 com.incomming(function(msg) {
     //parent.console.log('incomming msg', internals.id, msg);
-    if (msg.cmd === 'callback' && utility.isNumber(msg.index)) {
+    if (msg.cmd === 'callback' && typeof msg.index == 'number') {
         internals.callback(msg);
     } else if (msg.cmd === 'getSizes') {
         internals.processSize();

--- a/test/unit/utility.test.js
+++ b/test/unit/utility.test.js
@@ -7,22 +7,4 @@ describe('utility', function() {
         expect(utility).toEqual(jasmine.any(Object));
     });
 
-    it('isFunction', function(){
-        expect(utility.isFunction(function(){})).toBe(true);
-        expect(utility.isFunction(false)).toBe(false);
-    });
-
-    it('isUndef', function(){
-        expect(utility.isUndef()).toBe(true);
-        expect(utility.isUndef(undefined)).toBe(true);
-        expect(utility.isUndef(true)).toBe(false);
-    });
-
-
-    // it('isNodeList', function(){
-    //     var nodeList = document.getElementsByTagName('*');
-    //     console.log('nodeList', nodeList);
-    //     expect(utility.isNodeList(nodeList)).toBe(true);
-    // });
-
 });


### PR DESCRIPTION
Next up in the utility cleanup is the isType methods. They only do a simple typeof check, and all of the type-checks we do are numbers, strings and functions, and they have no weird behavior as far as I know. Rewrote code to use typeof, deleted methods from utilities and associated tests.
